### PR TITLE
Update search endpoint to azure ai search

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -10,6 +10,7 @@ from functions import (
     get_resources_by_batch,
     search_resources,
 )
+from shared.azure_search_client import get_search_client
 from shared.database import initialize_database
 
 # Initialize the function app
@@ -18,8 +19,11 @@ app = func.FunctionApp()
 # Initialize database connection
 db, collection = initialize_database()
 
+# Initialize Azure Search client
+search_client = get_search_client()
+
 # Register functions
 get_resources_by_batch.register_function(app, collection)
-search_resources.register_function(app, collection)
+search_resources.register_function(app, search_client)
 get_filters.register_function(app, collection, db["filter_values"])
 get_dependent_workloads.register_function(app, collection)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 azure-functions
+azure-search-documents
 pymongo==4.11.2
 python-dotenv
 requests==2.32.3

--- a/shared/azure_search_client.py
+++ b/shared/azure_search_client.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025 The Regents of the University of California
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import os
+
+from azure.core.credentials import AzureKeyCredential
+from azure.search.documents import SearchClient
+
+
+def get_search_client():
+    """
+    Creates and returns an Azure AI Search client.
+
+    Required environment variables:
+    - AZURE_SEARCH_ENDPOINT: The Azure AI Search service endpoint
+    - AZURE_SEARCH_API_KEY: The API key for authentication
+    - AZURE_SEARCH_INDEX_NAME: The name of the search index
+
+    Returns:
+        SearchClient: An Azure AI Search client instance
+    """
+    endpoint = os.environ.get("AZURE_SEARCH_ENDPOINT")
+    api_key = os.environ.get("AZURE_SEARCH_API_KEY")
+    index_name = os.environ.get("AZURE_SEARCH_INDEX_NAME")
+
+    if not all([endpoint, api_key, index_name]):
+        logging.error("Missing Azure Search configuration")
+        raise ValueError(
+            "Missing required environment variables: "
+            "AZURE_SEARCH_ENDPOINT, AZURE_SEARCH_API_KEY, or AZURE_SEARCH_INDEX_NAME"
+        )
+
+    credential = AzureKeyCredential(api_key)
+    client = SearchClient(
+        endpoint=endpoint, index_name=index_name, credential=credential
+    )
+
+    return client

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -49,10 +49,11 @@ def sanitize_contains_str(value):
 
 def sanitize_must_include(value):
     # Only allow field,value1,value2;field2,value1,value2, max 500 chars
+    # Allow dots for version numbers like "24.1"
     if not isinstance(value, str):
         return ""
     value = value.strip()
-    value = re.sub(r"[^\w,;\-]", "", value)
+    value = re.sub(r"[^\w,;\-\.]", "", value)
     return value[:500]
 
 


### PR DESCRIPTION
This PR updates the search endpoint to use Azure AI search instead of MongoDB Atlas `$search`.

We need to upddate this as the MongoDB database is moved form Atlas to CosmosDB.